### PR TITLE
feat: sort failed test report by latest test date

### DIFF
--- a/src/lib/fireHoseRepository.ts
+++ b/src/lib/fireHoseRepository.ts
@@ -476,7 +476,13 @@ export async function getFailedTestFireHoses(ownerId: string): Promise<FireHose[
     return latestMaintenance && !latestMaintenance.testPassed;
   });
 
-  return failedHoses.map((fireHose) => ({
+  const sortedByLatestTest = failedHoses.sort((a, b) => {
+    const dateA = a.maintenances[0]?.timestamp.getTime() ?? 0;
+    const dateB = b.maintenances[0]?.timestamp.getTime() ?? 0;
+    return dateB - dateA;
+  });
+
+  return sortedByLatestTest.map((fireHose) => ({
     ...fireHose,
     diameter: castToFireHoseDiameter(fireHose.diameter),
   }));


### PR DESCRIPTION
This pull request updates the logic in the `getFailedTestFireHoses` function to improve how failed fire hoses are returned. Now, the failed hoses are sorted so that the most recently tested hoses appear first, making it easier to prioritize recent failures.

Improvements to failed test fire hose ordering:

* In `src/lib/fireHoseRepository.ts`, the `getFailedTestFireHoses` function now sorts failed hoses by the timestamp of their latest maintenance, with the most recent first.