### PR TITLE
fix: use UTC timezone in date formatting function in Decommissioned R…

### DIFF
--- a/src/app/_components/decommissioned-report/decommissioned-report.tsx
+++ b/src/app/_components/decommissioned-report/decommissioned-report.tsx
@@ -20,6 +20,7 @@ function formatDate(date: Date): string {
     day: "2-digit",
     month: "2-digit",
     year: "numeric",
+    timeZone: "UTC",
   });
 }
 
@@ -31,6 +32,7 @@ function formatDateTime(date: Date): string {
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,
+    timeZone: "UTC",
   });
 }
 


### PR DESCRIPTION
This pull request updates the date and time formatting in the `decommissioned-report.tsx` component to ensure all formatted dates and times are displayed in UTC, which helps maintain consistency regardless of the user's local timezone.

Date and time formatting updates:

* Added the `timeZone: "UTC"` option to the `Intl.DateTimeFormat` calls in both the `formatDate` and `formatDateTime` functions to standardize date and time output to UTC. 