### PR TITLE
feat: move main navigation to header

### DIFF
--- a/src/app/_components/page-header.tsx
+++ b/src/app/_components/page-header.tsx
@@ -1,12 +1,43 @@
-import Link from "next/link";
+"use client";
 
-export default async function PageHeader() {
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export default function PageHeader() {
+  const pathname = usePathname();
+
+  const isHome = pathname === "/" || pathname.startsWith("/hose");
+  const isReports = pathname.startsWith("/reports");
+
   return (
-    <header className="flex flex-row justify-between p-5 drop-shadow-xs bg-gray-200  border-b border-gray-400">
-      <h1 className="text-3xl font-bold leading-none tracking-tight my-auto">
-        <Link href={"/"}>Schlauchverwaltung</Link>
-      </h1>
-      <div className={"text-gray-500"}>
+    <header className="flex flex-row justify-between p-5 drop-shadow-xs bg-gray-200 border-b border-gray-400">
+      <div className="flex items-baseline gap-8">
+        <h1 className="text-3xl font-bold leading-none tracking-tight">
+          <Link href={"/"}>Schlauchverwaltung</Link>
+        </h1>
+
+        <nav className="flex items-baseline">
+          <Link
+            href="/"
+            className={`text-xl px-4 py-1 ${
+              isHome ? "text-gray-900 font-medium" : "text-gray-600"
+            }`}
+          >
+            Reinigen & Prüfen
+          </Link>
+          <span className="text-gray-400 mx-1">|</span>
+          <Link
+            href="/reports"
+            className={`text-xl px-4 py-1 ${
+              isReports ? "text-gray-900 font-medium" : "text-gray-600"
+            }`}
+          >
+            Berichte
+          </Link>
+        </nav>
+      </div>
+
+      <div className="text-gray-500 my-auto">
         {process.env.NEXT_PUBLIC_APP_VERSION}
       </div>
     </header>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,10 +6,7 @@ export default async function Home() {
   return (
     <main className="p-6">
       <HoseSelector />
-      <div className="fixed bottom-6 right-6 flex gap-3">
-        <Link href={"/reports"}>
-          <TouchButton label="Berichte" className="rounded-full shadow-lg" />
-        </Link>
+      <div className="fixed bottom-6 right-6">
         <Link href={"/hose/new"}>
           <TouchButton
             label="Neuer Schlauch"

--- a/src/app/reports/decommissioned/decommissioned-report-adapter.tsx
+++ b/src/app/reports/decommissioned/decommissioned-report-adapter.tsx
@@ -5,8 +5,6 @@ import DateRangeSelector, {
   DateRangePreset,
 } from "@/app/_components/date-range-selector";
 import DecommissionedReport from "@/app/_components/decommissioned-report";
-import TouchButton from "@/app/_components/touch-button";
-import Link from "next/link";
 import { FireHose } from "@/lib/types";
 
 interface DecommissionedReportAdapterProps {
@@ -50,15 +48,6 @@ export default function DecommissionedReportAdapter({
         endDate={endDate}
         ownerName={ownerName}
       />
-
-      <div className="flex gap-4 mt-4">
-        <Link href="/reports">
-          <TouchButton label="Zurück zu Berichte" />
-        </Link>
-        <Link href="/">
-          <TouchButton label="Zur Startseite" />
-        </Link>
-      </div>
     </div>
   );
 }

--- a/src/app/reports/failed-test/page.tsx
+++ b/src/app/reports/failed-test/page.tsx
@@ -1,10 +1,8 @@
 import { getFailedTestFireHoses } from "@/lib/fireHoseRepository";
 import { OWNER_MURRHARDT } from "@/lib/static";
 import FailedTestReport from "@/app/_components/failed-test-report";
-import TouchButton from "@/app/_components/touch-button";
-import Link from "next/link";
 
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 export default async function FailedTestReportPage() {
   const hoses = await getFailedTestFireHoses(OWNER_MURRHARDT.id);
@@ -15,15 +13,6 @@ export default async function FailedTestReportPage() {
 
       <div className="w-full max-w-6xl">
         <FailedTestReport hoses={hoses} ownerName={OWNER_MURRHARDT.name} />
-      </div>
-
-      <div className="flex gap-4 mt-4">
-        <Link href="/reports">
-          <TouchButton label="Zurück zu Berichte" />
-        </Link>
-        <Link href="/">
-          <TouchButton label="Zur Startseite" />
-        </Link>
       </div>
     </main>
   );

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -1,6 +1,4 @@
 import ReportCard from "@/app/_components/report-card";
-import TouchButton from "@/app/_components/touch-button";
-import Link from "next/link";
 
 export default async function ReportsPage() {
   return (
@@ -18,12 +16,6 @@ export default async function ReportsPage() {
           description="Schläuche, die die letzte Prüfung nicht bestanden haben"
           href="/reports/failed-test"
         />
-      </div>
-
-      <div className="mt-6">
-        <Link href="/">
-          <TouchButton label="Zurück zur Startseite" />
-        </Link>
       </div>
     </main>
   );


### PR DESCRIPTION
This pull request updates the navigation experience and streamlines the UI by moving key navigation links into the header and removing redundant navigation buttons from individual pages. The main navigation is now more consistent and accessible, and unnecessary code has been cleaned up.

Navigation improvements:

* Added a navigation bar to the `PageHeader` component, allowing users to switch between "Reinigen & Prüfen" and "Berichte" directly from the header. The active section is visually highlighted. (`src/app/_components/page-header.tsx`)
* Removed the floating "Berichte" button from the home page, as this navigation is now handled in the header. (`src/app/page.tsx`)

Code and UI cleanup:

* Removed redundant "Zurück" (Back) and "Zur Startseite" (To Home) buttons from the reports and decommissioned report pages, as navigation is now centralized in the header. (`src/app/reports/decommissioned/decommissioned-report-adapter.tsx`, `src/app/reports/failed-test/page.tsx`, `src/app/reports/page.tsx`) [[1]](diffhunk://#diff-f12d66d225ece7e8063890b57e5fbf21478915af1ea39fd55d94c00a6a9223c5L8-L9) [[2]](diffhunk://#diff-f12d66d225ece7e8063890b57e5fbf21478915af1ea39fd55d94c00a6a9223c5L53-L61) [[3]](diffhunk://#diff-58c61d95729a4705ca4bf1b31079ae226c764ffbb3d26c2f2c2e93a50c785ff1L4-R5) [[4]](diffhunk://#diff-58c61d95729a4705ca4bf1b31079ae226c764ffbb3d26c2f2c2e93a50c785ff1L19-L27) [[5]](diffhunk://#diff-a1ddba5b1d93fe8db8d4d77ccebb062743b0e59507d26e8b61e1c25562e5cd87L2-L3) [[6]](diffhunk://#diff-a1ddba5b1d93fe8db8d4d77ccebb062743b0e59507d26e8b61e1c25562e5cd87L22-L27)